### PR TITLE
Change case of Class Name WoocommerceApi => WooCommerceApi.

### DIFF
--- a/src/Facades/WoocommerceFacade.php
+++ b/src/Facades/WoocommerceFacade.php
@@ -13,6 +13,6 @@ class WoocommerceFacade extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Codexshaper\Woocommerce\WoocommerceApi';
+        return 'Codexshaper\Woocommerce\WooCommerceApi';
     }
 }

--- a/src/WooCommerceApi.php
+++ b/src/WooCommerceApi.php
@@ -5,7 +5,7 @@ namespace Codexshaper\WooCommerce;
 use Automattic\WooCommerce\Client;
 use Codexshaper\WooCommerce\Traits\WoocommerceTrait;
 
-class WoocommerceApi
+class WooCommerceApi
 {
     use WooCommerceTrait;
 

--- a/src/WooCommerceServiceProvider.php
+++ b/src/WooCommerceServiceProvider.php
@@ -33,6 +33,6 @@ class WooCommerceServiceProvider extends ServiceProvider
         $this->app->singleton('WooCommerceApi', function () {
             return new WooCommerceApi();
         });
-        $this->app->alias('Codexshaper\Woocommerce\WooCommerceApi', 'WoocommerceApi');
+        $this->app->alias('Codexshaper\Woocommerce\WooCommerceApi', 'WooCommerceApi');
     }
 }


### PR DESCRIPTION
Hello!
This is my first "pull request". Sorry if I don't do it right.
The package generates the following error on my production server:
  "Class Codexshaper \\ WooCommerce \\ WooCommerceApi does not exist",

Reviewing, I see that the class name really is WocommerceApi.
I see that in the "Register Provider" there is an alias, but still I have not got it to work.

Finally I have chosen to fork and rename the class and the file name.

If it is correct, I would appreciate if you accept the "pull request" to reconnect my project directly to your repository and enjoy the next updates.

If I am wrong, I would also appreciate if you could explain how to solve it.

Thank you.