### PR TITLE
typo on model name.

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -2,10 +2,10 @@
 
 namespace Codexshaper\WooCommerce;
 
-use Codexshaper\WooCommerce\Models\BaseMOdel;
+use Codexshaper\WooCommerce\Models\BaseModel;
 use Codexshaper\WooCommerce\Traits\QueryBuilderTrait;
 
-class Query extends BaseMOdel
+class Query extends BaseModel
 {
     use QueryBuilderTrait;
 


### PR DESCRIPTION
important for case sensitive environment like Linux