### PR TITLE
add integration for woocommerce admin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
                 "Variation": "Codexshaper\\WooCommerce\\Models\\Variation",
                 "Webhook": "Codexshaper\\WooCommerce\\Facades\\Webhook",
                 "WooCommerce": "Codexshaper\\WooCommerce\\Facades\\WooCommerce",
+                "WooAnalytics": "Codexshaper\\WooCommerce\\Facades\\WooAnalytics",
                 "Query": "Codexshaper\\WooCommerce\\Facades\\Query"
             }
         }

--- a/src/Facades/WooAnalytics.php
+++ b/src/Facades/WooAnalytics.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Codexshaper\WooCommerce\Facades;
+
+use Codexshaper\WooCommerce\WooCommerceAnalyticsApi;
+use Illuminate\Support\Facades\Facade;
+
+class WooAnalytics extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return WooCommerceAnalyticsApi::class;
+    }
+}

--- a/src/WooCommerceAnalyticsApi.php
+++ b/src/WooCommerceAnalyticsApi.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Codexshaper\WooCommerce;
+
+use Automattic\WooCommerce\Client;
+use Codexshaper\WooCommerce\Traits\WooCommerceTrait;
+
+class WooCommerceAnalyticsApi
+{
+    use WooCommerceTrait;
+
+    /**
+     *@var \Automattic\WooCommerce\Client
+     */
+    protected $client;
+
+    /**
+     *@var array
+     */
+    protected $headers = [];
+
+    /**
+     * Build Woocommerce connection.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        try {
+            $this->headers = [
+                'header_total'       => config('woocommerce.header_total') ?? 'X-WP-Total',
+                'header_total_pages' => config('woocommerce.header_total_pages') ?? 'X-WP-TotalPages',
+            ];
+
+            $this->client = new Client(
+                config('woocommerce.store_url'),
+                config('woocommerce.consumer_key'),
+                config('woocommerce.consumer_secret'),
+                [
+                    'version'           => 'wc-analytics',
+                    'wp_api'            => config('woocommerce.wp_api_integration'),
+                    'verify_ssl'        => config('woocommerce.verify_ssl'),
+                    'query_string_auth' => config('woocommerce.query_string_auth'),
+                    'timeout'           => config('woocommerce.timeout'),
+                ]
+            );
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage(), 1);
+        }
+    }
+}


### PR DESCRIPTION
Since WooCommerce Admin is [a part of WooCommerce](https://developer.woocommerce.com/2021/10/14/rfc-woocommerce-admin-is-merging-into-core/) for a while now. It would be helpful to integrate it in laravel-woocommerce.

Since the reports you will get from `.../wc/v3/reports/` include very little data they are not that useful for most users.

Integrating the analyses we get from [WooCommerce Admin](https://github.com/woocommerce/woocommerce-admin) could help here.

For example:
I have created a new Coupon via laravel-woocommerce like 

```php
$data = [
    'code' => '10off',
    'discount_type' => 'percent',
    'amount' => '10',
    'individual_use' => true,
    'exclude_sale_items' => true,
    'minimum_amount' => '100.00'
];

$coupon = Coupon::create($data);
$coupon_id = $coupon->id;
YourModel::
```
and the server responds with the coupon

```json
{
  "id": 719,
  "code": "10off",
  ...
}
```
now using the ID we can easily track the coupon from outside like

```php
$coupons = WooAnalytics::all('reports/coupons', [
  'coupons'   => $coupon_id,
  'before'     => date('Y-m-d\T00:00:00', time()),
  'after'    => $coupon->date_created,
  ...
]);
```

If this is something you are willing to merge I would add some changes to this PR.

This would include:
- Adding a new trait for WooCommerce Admin / Analytics to ensure only actions that can be done via the endpoint are reflected
- Easier access to the endpoint by removing the `reports/` part
- Automatic datetime transitions
- implementing a working `find` method
- Possible ideas that come up in the comments

Let me know what you think.

