### PR TITLE
Add support for WooCommerce Subscriptions endpoints

### DIFF
--- a/src/Facades/Subscription.php
+++ b/src/Facades/Subscription.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Codexshaper\WooCommerce\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class Subscription extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'Codexshaper\WooCommerce\Models\Subscription';
+    }
+}

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Codexshaper\WooCommerce\Models;
+
+use Codexshaper\WooCommerce\Facades\Query;
+use Codexshaper\WooCommerce\Traits\QueryBuilderTrait;
+
+class Subscription extends BaseModel
+{
+    use QueryBuilderTrait;
+
+    protected $endpoint = 'subscriptions';
+
+    /**
+     * Retrieve all notes.
+     *
+     * @param int   $subscription_id
+     * @param array $options
+     *
+     * @return array
+     */
+    protected function notes($subscription_id, $options = [])
+    {
+        return Query::init()
+            ->setEndpoint("subscription/{$subscription_id}/notes")
+            ->all($options);
+    }
+
+    /**
+     * Retreive a note.
+     *
+     * @param int   $subscription_id
+     * @param int   $note_id
+     * @param array $options
+     *
+     * @return object
+     */
+    protected function note($subscription_id, $note_id, $options = [])
+    {
+        return Query::init()
+            ->setEndpoint("subscriptions/{$subscription_id}/notes")
+            ->find($note_id, $options);
+    }
+
+    /**
+     * Create a note.
+     *
+     * @param int   $subscription_id
+     * @param array $data
+     *
+     * @return object
+     */
+    protected function createNote($subscription_id, $data = [])
+    {
+        return Query::init()
+            ->setEndpoint("subscriptions/{$subscription_id}/notes")
+            ->create($data);
+    }
+
+    /**
+     * Delete a note.
+     *
+     * @param int   $subscription_id
+     * @param int   $note_id
+     * @param array $options
+     *
+     * @return object
+     */
+    protected function deleteNote($subscription_id, $note_id, $options = [])
+    {
+        return Query::init()
+            ->setEndpoint("subscriptions/{$subscription_id}/notes")
+            ->delete($note_id, $options);
+    }
+
+    /**
+     * Retrieve all orders for the subscription.
+     *
+     * @param int   $subscription_id
+     * @param array $options
+     *
+     * @return array
+     */
+    protected function orders($subscription_id, $options = [])
+    {
+        return Query::init()
+            ->setEndpoint("subscriptions/{$subscription_id}/orders")
+            ->all($options);
+    }
+}

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -22,7 +22,7 @@ class Subscription extends BaseModel
     protected function notes($subscription_id, $options = [])
     {
         return Query::init()
-            ->setEndpoint("subscription/{$subscription_id}/notes")
+            ->setEndpoint("subscriptions/{$subscription_id}/notes")
             ->all($options);
     }
 


### PR DESCRIPTION
This PR adds support for API endpoints provided by the [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/) extension, which are documented at https://woocommerce.github.io/subscriptions-rest-api-docs/
While it is not a part of WooCommerce core, it is widely used and so I think this addition could be useful to those who manage subscriptions, and would not create any issues for those who don't. Let me know if you have any requests or feedback.
Fixes #73.